### PR TITLE
Implement sending emails using the Gmail API and OAuth 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,18 +15,29 @@ The WAM Spam script has the following dependencies:
 
 * [Requests](https://2.python-requests.org/en/master/) and [beautifulsoup4](https://www.crummy.com/software/BeautifulSoup/bs4/doc/), third-party Python packages for web scraping.
 
-* [Google API Python Client](https://github.com/googleapis/google-api-python-client) and [Google OAuth](https://github.com/googleapis/google-auth-library-python-oauthlib), third-party Python packages for sending emails using the Gmail API.
+    Easily install with [pip](https://pypi.python.org/pypi/pip) using the commands `pip3 install requests beautifulsoup4` or `pip3 install -r requirements.txt`, or however else you prefer to install Python packages.
 
-Easily install the Python packages with [pip](https://pypi.python.org/pypi/pip) using the commands `pip3 install requests beautifulsoup4 google-api-python-client google-auth-oauthlib` or `pip3 install -r requirements.txt`, or however else you prefer to install Python packages.
+If using the Gmail API with OAuth 2.0 (enabled by default), the script also has the following dependencies:
 
-**You must obtain an OAuth 2.0 Client ID from the [Google API Console](https://console.developers.google.com) for the script to be able to send emails.** Save this in the file specified by `CLIENT_ID_PATH` in `mailer.py`.
+* [Google API Python Client](https://github.com/googleapis/google-api-python-client) (`pip3 install google-api-python-client`)
+* [Google OAuth](https://github.com/googleapis/google-auth-library-python-oauthlib) (`pip3 install google-auth-oauthlib`)
 
+    **You must obtain an OAuth 2.0 Client ID from the [Google API Console](https://console.developers.google.com) for the script to be able to send emails.** Save this in the file specified by `CLIENT_ID_PATH` in the `APIMailer` class of `mailer.py`.
+
+If you do not wish to use the Gmail API (not recommended), set `LEGACY_AUTH` to `True` in `wamspam.py`. The last two dependencies are not required; remove the `APIMailer` class and the following imports from `mailer.py`:
+
+```
+from googleapiclient.discovery import build
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
+from googleapiclient.errors import HttpError
+```
 
 ## Configuration
 
 While the script has sensible default settings, it's also easily configurable. You can modify the constants atop `wamspam.py` to easily change the behaviour. Some important configuration options are:
 
-* `DEGREE_INDEX`: **This one's important!** If you have multiple degrees, then you need oto tell the script which degree's WAM you want it to monitor. Just specify a (zero-based) index into the list of degrees on your results page (0 for the top degree in the list, 1 for the second, and so on). If you only have a single degree, you can leave this value.
+* `DEGREE_INDEX`: **This one's important!** If you have multiple degrees, then you need to tell the script which degree's WAM you want it to monitor. Just specify a (zero-based) index into the list of degrees on your results page (0 for the top degree in the list, 1 for the second, and so on). If you only have a single degree, you can leave this value.
 
 
 * `CHECK_REPEATEDLY`: By default, the script will repeatedly check your WAM until you kill it. If you want the script to check your WAM only once, set this to `False`.
@@ -41,9 +52,9 @@ Once you have installed the requirements and configured the script, simply run i
 
 The script will ask you for your unimelb username and password. It uses these to log into the results page on your behalf every however-many minutes you configured, looking for your WAM. It stores the previous WAM in a text file between checks, for comparison.
 
-The first time you run the script, you will be asked to authenticate and grant permission to send email on your behalf.
+If using the Gmail API (default), you will be asked to authenticate and grant permission to send email on your behalf the first time you run the script.
 
-The first time the script finds your WAM, or whenever it sees your WAM change, the script will also log in to your university email and send you a self-email notifying you about the WAM change. Now you can compulsively check your email, instead of compulsively checking the results page! Haha.
+The first time the script finds your WAM, or whenever it sees your WAM change, the script will send you a self-email notifying you about the WAM change. Now you can compulsively check your email, instead of compulsively checking the results page! Haha.
 
 > Note: Don't forget to stop the script after the final results release date!
 
@@ -54,3 +65,8 @@ The script is not very robust. If anything goes wrong, it will probably crash wi
 ##### The script crashes with an error: `InvalidLoginException`.
 
 You might have typed your username or password wrong. Please check that you got them right, and try again.
+
+
+##### The script crashes when logging in to my email account, with error `smtplib.SMTPAuthenticationError: (535, b'5.7.8 Username and Password not accepted` or similar.
+
+It sounds like you have set `LEGACY_AUTH` to `True` and Google is blocking the script's attempt to log in to its SMTP server. This is because the way the script logs into your account with this setting does not meet Google's security standards. The solution is to go to https://myaccount.google.com/u/2/lesssecureapps?pageId=none and turn the "allow less secure apps" option on. Remember to turn it off when you get your results.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,12 @@ The WAM Spam script has the following dependencies:
 * [Python 3.6](https://www.python.org/) (or higher).
 
 * [Requests](https://2.python-requests.org/en/master/) and [beautifulsoup4](https://www.crummy.com/software/BeautifulSoup/bs4/doc/), third-party Python packages for web scraping.
-    * Easily install with [pip](https://pypi.python.org/pypi/pip) using the commands `pip3 install requests beautifulsoup4` or `pip3 install -r requirements.txt`, or however else you prefer to install Python packages.
+
+* [Google API Python Client](https://github.com/googleapis/google-api-python-client) and [Google OAuth](https://github.com/googleapis/google-auth-library-python-oauthlib), third-party Python packages for sending emails using the Gmail API.
+
+Easily install the Python packages with [pip](https://pypi.python.org/pypi/pip) using the commands `pip3 install requests beautifulsoup4 google-api-python-client google-auth-oauthlib` or `pip3 install -r requirements.txt`, or however else you prefer to install Python packages.
+
+**You must obtain an OAuth 2.0 Client ID from the [Google API Console](https://console.developers.google.com) for the script to be able to send emails.** Save this in the file specified by `CLIENT_ID_PATH` in `mailer.py`.
 
 
 ## Configuration
@@ -36,6 +41,8 @@ Once you have installed the requirements and configured the script, simply run i
 
 The script will ask you for your unimelb username and password. It uses these to log into the results page on your behalf every however-many minutes you configured, looking for your WAM. It stores the previous WAM in a text file between checks, for comparison.
 
+The first time you run the script, you will be asked to authenticate and grant permission to send email on your behalf.
+
 The first time the script finds your WAM, or whenever it sees your WAM change, the script will also log in to your university email and send you a self-email notifying you about the WAM change. Now you can compulsively check your email, instead of compulsively checking the results page! Haha.
 
 > Note: Don't forget to stop the script after the final results release date!
@@ -47,12 +54,3 @@ The script is not very robust. If anything goes wrong, it will probably crash wi
 ##### The script crashes with an error: `InvalidLoginException`.
 
 You might have typed your username or password wrong. Please check that you got them right, and try again.
-
-
-##### The script crashes when logging in to my email account, with error `smtplib.SMTPAuthenticationError: (535, b'5.7.8 Username and Password not accepted` or similar.
-
-It sounds like Google may be blocking the script's attempt to log in to its SMTP server. This is because Google thinks the way the script logs into your account does not meet google's security standards. The solution is to go to https://myaccount.google.com/u/2/lesssecureapps?pageId=none and turn the "allow less secure app" option on. Remember to turn it off when you get your results.
-
-There may be a proper fix for this related to how the script tries to authenticate, but I don't know anything about SMTP authentication.
-
-Also, see Issue #4.

--- a/mailer.py
+++ b/mailer.py
@@ -1,0 +1,79 @@
+import base64
+import pickle
+import os.path
+
+from email.mime.text import MIMEText
+
+from googleapiclient.discovery import build
+from google_auth_oauthlib.flow import InstalledAppFlow
+from google.auth.transport.requests import Request
+from googleapiclient.errors import HttpError
+
+
+class Mailer:
+    """Class to send emails using the Gmail API and OAuth 2.0 Protocol.
+
+    To use this class, you must obtain an OAuth 2.0 Client ID from the
+    Google API Console (https://console.developers.google.com).
+    """
+
+    CLIENT_ID_PATH = 'credentials.json'
+    ACCESS_TOKEN_PATH = 'token.pickle'
+
+    SCOPES = ['https://www.googleapis.com/auth/gmail.send']
+
+    def __init__(self):
+        """Initialise a Mailer object. Prompt the user to authenticate and
+        provide mailing permissions if required.
+        """
+        self.creds = None
+        # if there's an access token from previous authentication, load it
+        if os.path.exists(self.ACCESS_TOKEN_PATH):
+            with open(self.ACCESS_TOKEN_PATH, 'rb') as token:
+                self.creds = pickle.load(token)
+
+        # if the credentials are invalid or non-existent, prompt to authenticate
+        if not self.creds or not self.creds.valid:
+            if self.creds and self.creds.expired and self.creds.refresh_token:
+                self.creds.refresh(Request())
+            else:
+                flow = InstalledAppFlow.from_client_secrets_file(
+                    self.CLIENT_ID_PATH, self.SCOPES)
+                self.creds = flow.run_local_server()
+            # save the credentials for the next run
+            with open(self.ACCESS_TOKEN_PATH, 'wb') as token:
+                pickle.dump(self.creds, token)
+
+        self.service = build('gmail', 'v1', credentials=self.creds)
+
+    @staticmethod
+    def create_message(sender, to, subject, body):
+        """Create a base-64 encoded email message.
+
+        :param sender: The sender
+        :param to: The recipient
+        :param subject: Subject line
+        :param body: Email body contents
+        :return: Object containing the base-64 encoded email message.
+        """
+        message = MIMEText(body)
+        message['to'] = to
+        message['from'] = sender
+        message['subject'] = subject
+        return {'raw': base64.urlsafe_b64encode(message.as_bytes()).decode()}
+
+    def send_message(self, user_id, message):
+        """Send an email message.
+
+        :param user_id: User's email address (the special value 'me'
+        can be used to indicate the authenticated user)
+        :param message: Message to be sent
+        :return: The sent message
+        """
+        try:
+            message = (self.service.users().messages()
+                       .send(userId=user_id, body=message).execute())
+            print(f'Email sent! Message Id: {message["id"]}')
+            return message
+        except HttpError as error:
+            print(f'An error occurred: {error}')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 requests
 beautifulsoup4
+google-api-python-client
+google-auth-oauthlib

--- a/wamspam.py
+++ b/wamspam.py
@@ -6,12 +6,11 @@ update, and then send the student a self-email if anything changed
 """
 import time
 import getpass
-import smtplib
-from email.mime.text import MIMEText
 
 import requests
 from bs4 import BeautifulSoup
 
+from mailer import Mailer
 
 # # #
 # SCRIPT CONFIGURATION
@@ -53,12 +52,8 @@ BS4_PARSER = "html.parser"
 # EMAIL CONFIGURATION
 # 
 
-# the script will send email from and to your student email address.
-# if you need to use an app-specific password to get around 2FA on
-# your email account, or other authentication issues, you can set it
-# here as the value of EMAIL_PASSWORD.
-EMAIL_ADDRESS  = UNIMELB_USERNAME + "@student.unimelb.edu.au"
-EMAIL_PASSWORD = UNIMELB_PASSWORD
+# the script will send email from and to this student email address.
+EMAIL_ADDRESS = UNIMELB_USERNAME + "@student.unimelb.edu.au"
 
 # here we specify the format of the email messages (customise to your liking)
 SUBJECT = "WAM Update Detected"
@@ -90,29 +85,33 @@ every so often---unless I crash! Every now and then you
 should probably check to make sure nothing has gone wrong.
 """
 
-# these are unlikely to change
-UNIMELB_SMTP_HOST = "smtp.gmail.com"
-UNIMELB_SMTP_PORT = 587
-
 
 # let's get to it!
 
 def main():
     """Run the checking script, once or forever, depending on configuration."""
+    # initialise the mailer; you will be asked to grant email permissions if
+    # this is the first time running the script.
+    mailer = Mailer()
+
     # conduct the first check! don't catch any exceptions here, if the
     # check fails this first time, it's likely to be a configuration problem
     # (e.g. wrong username/password) so we should crash the script to let the
     # user know.
-    poll_and_email()
+    poll_and_email(mailer)
     # also send a test message to make sure the email configuration is working
-    email_self(HELLO_SUBJECT, EMAIL_TEMPLATE.format(message=HELLO_MESSAGE))
+    message = mailer.create_message(sender=f'WAM Spammer <{EMAIL_ADDRESS}>',
+                                    to=EMAIL_ADDRESS, subject=HELLO_SUBJECT,
+                                    body=EMAIL_TEMPLATE.format(
+                                        message=HELLO_MESSAGE))
+    mailer.send_message(user_id='me', message=message)
 
     while CHECK_REPEATEDLY:
         print("Sleeping", DELAY_BETWEEN_CHECKS, "minutes before next check.")
         time.sleep(DELAY_BETWEEN_CHECKS * 60) # seconds
         print("Waking up!")
         try:
-            poll_and_email()
+            poll_and_email(mailer)
         except Exception as e:
             # if we get an exception now, it may have been some temporary
             # problem accessing the website, let's just ignore it and try
@@ -121,10 +120,12 @@ def main():
             print(f"{e.__class__.__name__}: {e}")
             print("Hopefully it won't happen again. Continuing.")
 
-def poll_and_email():
+def poll_and_email(mailer):
     """
     Check for an updated WAM, and send an email notification if any change is
     detected.
+
+    :param mailer: The Mailer object used for sending emails
     """
     # check the results page for the updated WAM
     new_wam_text = scrape_wam()
@@ -154,10 +155,13 @@ def poll_and_email():
         return
 
     # compose and send the message
-    message = message_template.format(before=old_wam, after=new_wam)
-    email_text = EMAIL_TEMPLATE.format(message=message)
-    email_self(SUBJECT, email_text)
-    
+    wam_text = message_template.format(before=old_wam, after=new_wam)
+    body_text = EMAIL_TEMPLATE.format(message=wam_text)
+    message = mailer.create_message(sender=f'WAM Spammer <{EMAIL_ADDRESS}>',
+                                    to=EMAIL_ADDRESS, subject=SUBJECT,
+                                    body=body_text)
+    mailer.send_message(user_id='me', message=message)
+
     # update the wam file for next time
     with open(WAM_FILENAME, 'w') as wamfile:
         wamfile.write(f"{new_wam}\n")
@@ -227,37 +231,6 @@ def scrape_wam(username=UNIMELB_USERNAME, password=UNIMELB_PASSWORD):
             wam_text = None
 
     return wam_text
-
-
-def email_self(subject, text, address=EMAIL_ADDRESS, password=EMAIL_PASSWORD):
-    """
-    Send an email from the student to the student (with provided email address
-    and password)
-
-    :param subject: The email subject line
-    :param text: The email body text
-    :param address: The email address to use (as SMTP login username, email 
-                    sender, and email recipient)
-    :param password: The password to use for SMTP server login.
-    """
-    print("Sending an email to self...")
-    print("From/To:", address)
-    print("Subject:", subject)
-    print("Message:", '"""', text, '"""', sep="\n")
-    
-    # make the email object
-    msg = MIMEText(text)
-    msg['To'] = address
-    msg['From'] = f"WAM Spammer <{address}>"
-    msg['Subject'] = subject
-
-    # log into the unimelb student email SMTP server (gmail) to send it
-    s = smtplib.SMTP(UNIMELB_SMTP_HOST, UNIMELB_SMTP_PORT)
-    s.ehlo(); s.starttls()
-    s.login(address, password)
-    s.sendmail(address, [address], msg.as_string())
-    s.quit()
-    print("Sent!")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds functionality to send emails using the Gmail API and OAuth 2.0 instead of SMTP and username/password authentication (the latter option is still retained).

A new module, `mailer.py`, is added with all email-related functionality contained within. There are three classes: `Mailer`, `APIMailer` and `SMTPMailer`. 

`Mailer` simply has one static method: `create_message()` which simply constructs an object containing a base-64 encoded MIME object following the RFC 2822 standard.

`APIMailer` is where the new functionality lies, as the `send_message()` method of this class sends an email using the Gmail API. In order to make use of this class, you **must** obtain an OAuth 2.0 Client ID from the [Google API Console](https://console.developers.google.com). The `__init__()` method of this class makes reference to it in order to request permission to send email on your behalf.

Old functionality using SMTP with username/password authentication is retained in the `SMTPMailer` class. If users do not wish to use OAuth, they can simply set the new `LEGACY_AUTH` configuration value to `True` in `wamspam.py`.

Let me know what you think!