### PR TITLE
Allow for multiple notification methods + Added desktop notifications and log file options

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,6 @@ The first time the script finds your WAM, or whenever it sees your WAM change, t
 
 ### Notification Options
 
-If you would like to use Pushbullet, install the `pushbullet.py` package: `pip install pushbullet.py`
-
 If you would like to use desktop notifications, install the `notify2` package: `pip install notify2`
 
 ### Common issues

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The first time the script finds your WAM, or whenever it sees your WAM change, t
 ### Notification Options
 
 If you would like to use Pushbullet, install the `pushbullet.py` package: `pip install pushbullet.py`
+
 If you would like to use desktop notifications, install the `notify2` package: `pip install notify2`
 
 ### Common issues

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The WAM Spam script has the following dependencies:
 
 While the script has sensible default settings, it's also easily configurable. You can modify the constants atop `wamspam.py` to easily change the behaviour. Some important configuration options are:
 
-* `DEGREE_INDEX`: **This one's important!** If you have multiple degrees, then you need oto tell the script which degree's WAM you want it to monitor. Just specify a (zero-based) index into the list of degrees on your results page (0 for the top degree in the list, 1 for the second, and so on). If you only have a single degree, you can leave this value.
+* `DEGREE_INDEX`: **This one's important!** If you have multiple degrees, then you need to tell the script which degree's WAM you want it to monitor. Just specify a (zero-based) index into the list of degrees on your results page (0 for the top degree in the list, 1 for the second, and so on). If you only have a single degree, you can leave this value.
 
 
 * `CHECK_REPEATEDLY`: By default, the script will repeatedly check your WAM until you kill it. If you want the script to check your WAM only once, set this to `False`.
@@ -39,6 +39,11 @@ The script will ask you for your unimelb username and password. It uses these to
 The first time the script finds your WAM, or whenever it sees your WAM change, the script will also log in to your university email and send you a self-email notifying you about the WAM change. Now you can compulsively check your email, instead of compulsively checking the results page! Haha.
 
 > Note: Don't forget to stop the script after the final results release date!
+
+### Notification Options
+
+If you would like to use Pushbullet, install the `pushbullet.py` package: `pip install pushbullet.py`
+If you would like to use desktop notifications, install the `notify2` package: `pip install notify2`
 
 ### Common issues
 

--- a/notification.py
+++ b/notification.py
@@ -85,7 +85,7 @@ class PushBulletNotification(NotificationHelper):
     """
     def __init__(self) -> None:
         from pushbullet import Pushbullet
-        token = input("PushBullet Access Token: ")
+        token = input("Pushbullet Access Token: ")
         self.pb = Pushbullet(token)
 
     def notify(self, subject: str, text: str) -> None:

--- a/notification.py
+++ b/notification.py
@@ -1,0 +1,75 @@
+import smtplib
+from email.mime.text import MIMEText
+import requests
+
+class NotificationHelper:
+    """
+    Interface for Notification Helper
+    """
+    def notify(self, subject: str, text: str) -> None:
+        """
+        Trigger the notification.
+
+        :param subject: The notification subject line
+        :param text: The notification body text
+        """
+        raise NotImplementedError()
+
+class EmailNotification(NotificationHelper):
+    """
+    Send an email from the student to the student (with provided email address and password)
+    """
+    def __init__(self, username: str, password: str) -> None:
+        # these are unlikely to change
+        self.UNIMELB_SMTP_HOST = "smtp.gmail.com"
+        self.UNIMELB_SMTP_PORT = 587
+
+        # the script will send email from and to your student email address.
+        # if you need to use an app-specific password to get around 2FA on
+        # your email account, or other authentication issues, you can set it
+        # here as the value of EMAIL_PASSWORD.
+        self.EMAIL_ADDRESS  = username + "@student.unimelb.edu.au"
+        self.EMAIL_PASSWORD = password
+
+    def notify(self, subject: str, text: str) -> None:
+        print("Sending an email to self...")
+        print("From/To:", self.EMAIL_ADDRESS)
+        print("Subject:", subject)
+        print("Message:", '"""', text, '"""', sep="\n")
+        
+        # make the email object
+        msg = MIMEText(text)
+        msg['To'] = self.EMAIL_ADDRESS
+        msg['From'] = f"WAM Spammer <{self.EMAIL_ADDRESS}>"
+        msg['Subject'] = subject
+
+        # log into the unimelb student email SMTP server (gmail) to send it
+        s = smtplib.SMTP(self.UNIMELB_SMTP_HOST, self.UNIMELB_SMTP_PORT)
+        s.ehlo(); s.starttls()
+        s.login(self.EMAIL_ADDRESS, self.EMAIL_PASSWORD)
+        s.sendmail(self.EMAIL_ADDRESS, [self.EMAIL_ADDRESS], msg.as_string())
+        s.quit()
+        print("Sent!")
+
+class ServerChanNotification(NotificationHelper):
+    """
+    Send notification to wechat using ServerChan.
+    http://sc.ftqq.com
+    """
+    def __init__(self) -> None:
+        token = input("SCKEY: ")
+        self.api = "https://sc.ftqq.com/{}.send".format(token)
+
+    def notify(self, subject: str, text: str) -> None:
+        print("Message:", '"""', text, '"""', sep="\n")
+        
+        data = {
+                "text": subject,
+                "desp": text
+        }
+        r = requests.get(self.api, params = data)
+        if r.json()["errno"] == 0:
+            print("Sent!", r.text)
+        else:
+            raise Exception(r.text)
+

--- a/notification.py
+++ b/notification.py
@@ -3,7 +3,6 @@ from email.mime.text import MIMEText
 from inspect import cleandoc
 
 import requests
-from pushbullet import Pushbullet
 from datetime import datetime
 
 class NotificationHelper:
@@ -85,6 +84,7 @@ class PushBulletNotification(NotificationHelper):
     https://www.pushbullet.com
     """
     def __init__(self) -> None:
+        from pushbullet import Pushbullet
         token = input("PushBullet Access Token: ")
         self.pb = Pushbullet(token)
 

--- a/notification.py
+++ b/notification.py
@@ -1,6 +1,7 @@
 import smtplib
 from email.mime.text import MIMEText
 import requests
+from pushbullet import Pushbullet
 
 class NotificationHelper:
     """
@@ -51,10 +52,11 @@ class EmailNotification(NotificationHelper):
         s.quit()
         print("Sent!")
 
+
 class ServerChanNotification(NotificationHelper):
     """
     Send notification to wechat using ServerChan.
-    http://sc.ftqq.com
+    https://sc.ftqq.com
     """
     def __init__(self) -> None:
         token = input("SCKEY: ")
@@ -73,3 +75,21 @@ class ServerChanNotification(NotificationHelper):
         else:
             raise Exception(r.text)
 
+
+class PushBulletNotification(NotificationHelper):
+    """
+    Send notification using PushBullet.
+    https://www.pushbullet.com
+    """
+    def __init__(self) -> None:
+        token = input("Access Token: ")
+        self.pb = Pushbullet(token)
+
+    def notify(self, subject: str, text: str) -> None:
+        print("Message:", '"""', text, '"""', sep="\n")
+        
+        push = self.pb.push_note(subject, text)
+        if push["active"]:
+            print("Sent!")
+        else:
+            raise Exception(str(push))

--- a/notification.py
+++ b/notification.py
@@ -4,6 +4,7 @@ from inspect import cleandoc
 
 import requests
 from pushbullet import Pushbullet
+from datetime import datetime
 
 class NotificationHelper:
     """
@@ -84,7 +85,7 @@ class PushBulletNotification(NotificationHelper):
     https://www.pushbullet.com
     """
     def __init__(self) -> None:
-        token = input("Access Token: ")
+        token = input("PushBullet Access Token: ")
         self.pb = Pushbullet(token)
 
     def notify(self, subject: str, text: str) -> None:
@@ -201,3 +202,32 @@ class IFTTTWebhookNotification(NotificationHelper):
             print("Triggered!", r.text)
         else:
             raise Exception(r.status_code, r.text)
+
+class DesktopNotification(NotificationHelper):
+    """
+    Sends a desktop notification using the notify2 python library (https://pypi.org/project/notify2/)
+    """
+
+    def __init__(self) -> None:
+        import notify2
+        notify2.init("UoM-WAM-Spam")
+        self.notification = notify2.Notification
+        self.timeout = notify2.EXPIRES_NEVER
+
+    def notify(self, subject: str, text: str) -> None:
+        n = self.notification(subject, text)
+        n.set_timeout(self.timeout)
+        n.show()
+
+class LogFile(NotificationHelper):
+    """
+    Writes 'notifications' to a local file.
+    """
+
+    def __init__(self) -> None:
+        self.fp = input("Enter the file path to log WAM changes to: ")
+
+    def notify(self, subject: str, text: str) -> None:
+        print("writing notification to log file at: ", self.fp)
+        with open(self.fp, 'a+') as f:
+            f.write('=' * 20 + '\nTime: ' + datetime.now().strftime('%a, %d %b %Y %H:%M:%S') + '\n' + subject + '\n' + text + '=' * 20 + '\n')

--- a/notification.py
+++ b/notification.py
@@ -84,18 +84,22 @@ class PushBulletNotification(NotificationHelper):
     https://www.pushbullet.com
     """
     def __init__(self) -> None:
-        from pushbullet import Pushbullet
-        token = input("Pushbullet Access Token: ")
-        self.pb = Pushbullet(token)
+        self.token = input("Pushbullet Access Token: ")
 
     def notify(self, subject: str, text: str) -> None:
         print("Message:", '"""', text, '"""', sep="\n")
-        
-        push = self.pb.push_note(subject, text)
-        if push["active"]:
-            print("Sent!")
+
+        data = {
+            "type": "note",
+            "title": subject,
+            "body": text
+        }
+
+        r = requests.post("https://api.pushbullet.com/v2/pushes", auth=(self.token, ''), json=data)
+        if r.status_code == 200:
+            print("Sent!", r.text)
         else:
-            raise Exception(str(push))
+            raise Exception(r.status_code, r.text)
 
 
 class TelegramBotNotification(NotificationHelper):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 requests
 beautifulsoup4
-pushbullet.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 beautifulsoup4
+pushbullet.py

--- a/wamspam.py
+++ b/wamspam.py
@@ -223,16 +223,24 @@ def scrape_wam(username=UNIMELB_USERNAME, password=UNIMELB_PASSWORD):
 def select_notification_method() -> NotificationHelper:
     print()
 
-    methods = ["Email", "PushBullet", "ServerChan (WeChat)"]
+    methods = ["Email", "PushBullet", "ServerChan (WeChat)", "Telegram Bot", "IFTTT Webhook"]
     for i, m in enumerate(methods):
         print("{}: {}".format(i, m))
-    i = int(input("Please select a notification method:") or 0)
+    i = int(input("Please select a notification method [0]:") or 0)
     print(methods[i])
 
     if i == 0:
         return EmailNotification(UNIMELB_USERNAME, UNIMELB_PASSWORD)
+    elif i == 1:
+        return PushBulletNotification()
+    elif i == 2:
+        ServerChanNotification()
+    elif i == 3:
+        TelegramBotNotification()
+    elif i == 4:
+        IFTTTWebhookNotification()
     else:
-        return PushBulletNotification() if i == 1 else ServerChanNotification()
+        print(i, "is not a invalid choice. Please try again.")
 
 
 if __name__ == '__main__':

--- a/wamspam.py
+++ b/wamspam.py
@@ -231,7 +231,9 @@ def select_notification_method() -> NotificationHelper:
         ("PushBullet", PushBulletNotification),
         ("ServerChan (WeChat)", ServerChanNotification),
         ("Telegram Bot", TelegramBotNotification),
-        ("IFTTT Webhook", IFTTTWebhookNotification)
+        ("IFTTT Webhook", IFTTTWebhookNotification),
+        ("Desktop Notifications", DesktopNotification),
+        ("Log File", LogFile)
     ]
     for i, m in enumerate(methods):
         print("{}: {}".format(i, m[0]))

--- a/wamspam.py
+++ b/wamspam.py
@@ -42,7 +42,7 @@ WAM_FILENAME = "wam.txt"
 # if you have multiple degrees, set this to the id of the degree with the WAM
 # you want the script to watch (0, 1, 2, ... based on order from results page).
 # if you only have a single degree, you can ignore this one.
-DEGREE_INDEX = 0
+DEGREE_INDEX = int(input("Degree index: ") or 0)
 
 # select the HTML parser for BeautifulSoup to use. in most cases, you won't
 # have to touch this.

--- a/wamspam.py
+++ b/wamspam.py
@@ -10,6 +10,7 @@ import getpass
 import requests
 from bs4 import BeautifulSoup
 
+from functools import partial
 from notification import *
 
 
@@ -42,7 +43,7 @@ WAM_FILENAME = "wam.txt"
 # if you have multiple degrees, set this to the id of the degree with the WAM
 # you want the script to watch (0, 1, 2, ... based on order from results page).
 # if you only have a single degree, you can ignore this one.
-DEGREE_INDEX = int(input("Degree index: ") or 0)
+DEGREE_INDEX = int(input("Degree index (or just press enter): ") or 0)
 
 # select the HTML parser for BeautifulSoup to use. in most cases, you won't
 # have to touch this.
@@ -93,18 +94,19 @@ def main():
     # user know.
 
     # notification_helper = EmailNotification(UNIMELB_USERNAME, UNIMELB_PASSWORD)
-    notification_helper = select_notification_method()
+    notification_helpers = select_notification_method()
 
-    poll_and_email(notification_helper)
+    poll_and_notify(notification_helpers)
     # also send a test message to make sure the email configuration is working
-    notification_helper.notify(HELLO_SUBJECT, EMAIL_TEMPLATE.format(message=HELLO_MESSAGE))
+    for notification_helper in notification_helpers:
+        notification_helper.notify(HELLO_SUBJECT, EMAIL_TEMPLATE.format(message=HELLO_MESSAGE))
 
     while CHECK_REPEATEDLY:
         print("Sleeping", DELAY_BETWEEN_CHECKS, "minutes before next check.")
         time.sleep(DELAY_BETWEEN_CHECKS * 60) # seconds
         print("Waking up!")
         try:
-            poll_and_email(notification_helper)
+            poll_and_notify(notification_helpers)
         except Exception as e:
             # if we get an exception now, it may have been some temporary
             # problem accessing the website, let's just ignore it and try
@@ -113,7 +115,7 @@ def main():
             print(f"{e.__class__.__name__}: {e}")
             print("Hopefully it won't happen again. Continuing.")
 
-def poll_and_email(notification_helper: NotificationHelper):
+def poll_and_notify(notification_helpers):
     """
     Check for an updated WAM, and send an email notification if any change is
     detected.
@@ -142,13 +144,14 @@ def poll_and_email(notification_helper: NotificationHelper):
     elif new_wam < old_wam:
         message_template = DECREASE_MESSAGE_TEMPLATE
     else:
-        print("No change to WAM---stop before sending an email.")
+        print("No change to WAM---stop before triggering notifications.")
         return
 
     # compose and send the message
     message = message_template.format(before=old_wam, after=new_wam)
     email_text = EMAIL_TEMPLATE.format(message=message)
-    notification_helper.notify(SUBJECT, email_text)
+    for notification_helper in notification_helpers:
+        notification_helper.notify(SUBJECT, email_text)
     
     # update the wam file for next time
     with open(WAM_FILENAME, 'w') as wamfile:
@@ -223,24 +226,28 @@ def scrape_wam(username=UNIMELB_USERNAME, password=UNIMELB_PASSWORD):
 def select_notification_method() -> NotificationHelper:
     print()
 
-    methods = ["Email", "PushBullet", "ServerChan (WeChat)", "Telegram Bot", "IFTTT Webhook"]
+    methods = [
+        ("Email", partial(EmailNotification, UNIMELB_USERNAME, UNIMELB_PASSWORD)),
+        ("PushBullet", PushBulletNotification),
+        ("ServerChan (WeChat)", ServerChanNotification),
+        ("Telegram Bot", TelegramBotNotification),
+        ("IFTTT Webhook", IFTTTWebhookNotification)
+    ]
     for i, m in enumerate(methods):
-        print("{}: {}".format(i, m))
-    i = int(input("Please select a notification method [0]:") or 0)
-    print(methods[i])
+        print("{}: {}".format(i, m[0]))
+    inp = input("Please select your preferred notification method(s) (comma delimited): ")
+    try:
+        selected = set([int(i) for i in inp.split(',')])
+        print("You have selected:", ", ".join([methods[i][0] for i in selected]))
+    except:
+        print(f"There was an error in your input, defaulting to method 0: {methods[0][0]}")
+        return [methods[0][1]()]
 
-    if i == 0:
-        return EmailNotification(UNIMELB_USERNAME, UNIMELB_PASSWORD)
-    elif i == 1:
-        return PushBulletNotification()
-    elif i == 2:
-        ServerChanNotification()
-    elif i == 3:
-        TelegramBotNotification()
-    elif i == 4:
-        IFTTTWebhookNotification()
-    else:
-        print(i, "is not a invalid choice. Please try again.")
+    helpers = []
+    for i in selected:
+        helpers.append(methods[i][1]())
+
+    return helpers
 
 
 if __name__ == '__main__':

--- a/wamspam.py
+++ b/wamspam.py
@@ -228,7 +228,7 @@ def select_notification_method() -> NotificationHelper:
 
     methods = [
         ("Email", partial(EmailNotification, UNIMELB_USERNAME, UNIMELB_PASSWORD)),
-        ("PushBullet", PushBulletNotification),
+        ("Pushbullet", PushBulletNotification),
         ("ServerChan (WeChat)", ServerChanNotification),
         ("Telegram Bot", TelegramBotNotification),
         ("IFTTT Webhook", IFTTTWebhookNotification),

--- a/wamspam.py
+++ b/wamspam.py
@@ -93,7 +93,7 @@ def main():
     # user know.
 
     # notification_helper = EmailNotification(UNIMELB_USERNAME, UNIMELB_PASSWORD)
-    notification_helper = ServerChanNotification()
+    notification_helper = select_notification_method()
 
     poll_and_email(notification_helper)
     # also send a test message to make sure the email configuration is working
@@ -219,6 +219,21 @@ def scrape_wam(username=UNIMELB_USERNAME, password=UNIMELB_PASSWORD):
             wam_text = None
 
     return wam_text
+
+def select_notification_method() -> NotificationHelper:
+    print()
+
+    methods = ["Email", "PushBullet", "ServerChan (WeChat)"]
+    for i, m in enumerate(methods):
+        print("{}: {}".format(i, m))
+    i = int(input("Please select a notification method:") or 0)
+    print(methods[i])
+
+    if i == 0:
+        return EmailNotification(UNIMELB_USERNAME, UNIMELB_PASSWORD)
+    else:
+        return PushBulletNotification() if i == 1 else ServerChanNotification()
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This is a fork of @blueset\'s fork (#9) of @CaviarChen\'s fork (#7) with the more modular notification interface.

Changes:
- Let the user select multiple notification methods.
- Support for desktop notifications (using [notify2](https://pypi.org/project/notify2/)) (tested on Arch Linux with libnotify)
- Support for a log file notification helper (simply write the email contents to a file, timestamped) (as an alternative for redirecting stdout and stderr to a file for people who don't want to hardcode creds and options)
- Removed the pushbullet dependency from `requirements.txt` and added instructions in the README for it. It still works, just that it is imported only if the user selects it as a notification metod so the program can run without crashing while also not importing or requiring it if unused.