### PR TITLE
add timestamp for easy reference

### DIFF
--- a/wamspam.py
+++ b/wamspam.py
@@ -6,6 +6,7 @@ update, and then send the student a notification if anything changed
 """
 import json
 import time
+from datetime import datetime
 import getpass
 
 import requests
@@ -159,9 +160,15 @@ def main():
     poll_and_notify()
 
     while CHECK_REPEATEDLY:
+        # print out current time for easy reference
+        print("Completed a check at", datetime.now().strftime("%H:%M:%S"))
         print("Sleeping", DELAY_BETWEEN_CHECKS, "minutes before next check.")
-        time.sleep(DELAY_BETWEEN_CHECKS * 60) # seconds
-        print("Waking up!")
+        print("--------------------------------------")
+        # execute sleep
+        time.sleep(DELAY_BETWEEN_CHECKS * 60) # seconds        
+        # time to wake up!
+        print("Waking up at", datetime.now().strftime("%H:%M:%S"))
+
         try:
             poll_and_notify()
         except Exception as e:


### PR DESCRIPTION
I thought it might be nice to have a timestamp in the logs so that you can see when the results were last checked / when they are next due to be checked.

Feedback / suggestions welcome.

Sample updated output format attached:

![wamspam-timestamp](https://user-images.githubusercontent.com/8280467/100814373-ab153f80-3495-11eb-8498-4dbc666f635b.png)
